### PR TITLE
integracion de roles

### DIFF
--- a/.github/workflows/deploy_local.yml
+++ b/.github/workflows/deploy_local.yml
@@ -1,8 +1,6 @@
 name: Despliegue Docker local de RoomOps
 
 on:
-  push:
-    branches: ["master"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ejecutar_test.yaml
+++ b/.github/workflows/ejecutar_test.yaml
@@ -1,0 +1,31 @@
+name: Ejecutar Test en Pull Request
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Run tests with Maven
+        run: mvn clean test
+
+      - name: Generate JaCoCo report
+        run: mvn jacoco:report
+
+      - name: Upload JaCoCo report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+target/
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -1,97 +1,120 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.springframework.boot</groupId>
-		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.3</version>
-		<relativePath/> <!-- lookup parent from repository -->
-	</parent>
-	<groupId>com.hoteleria</groupId>
-	<artifactId>roomsOps</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name/>
-	<description/>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-h2console</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc</artifactId>
-		</dependency>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-		<dependency>
-			<groupId>com.h2database</groupId>
-			<artifactId>h2</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webmvc-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <modelVersion>4.0.0</modelVersion>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.hoteleria</groupId>
+    <artifactId>roomsOps</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+
+        <!-- Web (REST Controllers) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- JPA -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+
+        <!-- H2 (DB en memoria) -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!--  TESTING -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+
+            <!-- Compiler -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <!-- Spring Boot -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <!--  JaCoCo (coverage automático) -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+
+                    <!-- Activa agente -->
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- Genera reporte -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/com/hoteleria/roomsOps/config/Initializer.java
+++ b/src/main/java/com/hoteleria/roomsOps/config/Initializer.java
@@ -1,0 +1,66 @@
+/* 
+
+package com.hoteleria.roomsOps.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.hoteleria.roomsOps.model.Role;
+import com.hoteleria.roomsOps.model.User;
+
+
+@Component
+public class Initializer implements CommandLineRunner {
+
+    @Autowired
+    private RoleRepo roleRepo;
+
+    @Autowired
+    private UserRepo userRepo;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) throws Exception {
+        // Crear roles por defecto si no existen
+        createRoleIfNotExists("administrador");
+        createRoleIfNotExists("cliente");
+        createRoleIfNotExists("usuario");
+        
+        // Crear usuarios por defecto si no existen
+        createUserIfNotExists("00000000-0", "admin", "admin", "admin@duoc.cl", "admin123", "administrador");
+
+        System.out.println("✓ Datos inicializados correctamente");
+    }
+
+    private void createRoleIfNotExists(String roleName) {
+        if (roleRepo.findByName(roleName).isEmpty()) {
+            Role role = new Role();
+            role.setName(roleName);
+            roleRepo.save(role);
+            System.out.println("✓ Rol creado: " + roleName);
+        }
+    }
+
+    private void createUserIfNotExists(String run, String firstName, String lastName, String email, String password, String roleName) {
+        if (userRepo.findByEmail(email).isEmpty()) {
+            Role role = roleRepo.findByName(roleName)
+                .orElseThrow(() -> new RuntimeException("Rol no encontrado: " + roleName));
+            
+            User user = new User();
+            user.setRun(run);
+            user.setFirstName(firstName);
+            user.setLastName(lastName);
+            user.setEmail(email);
+            user.setPassword(passwordEncoder.encode(password)); // Encriptar contraseña
+            user.setRole(role);
+            userRepo.save(user);
+            System.out.println("✓ Usuario creado: " + email + " con rol: " + roleName);
+        }
+    }
+}
+
+*/

--- a/src/main/java/com/hoteleria/roomsOps/controller/RoleController.java
+++ b/src/main/java/com/hoteleria/roomsOps/controller/RoleController.java
@@ -1,0 +1,82 @@
+package com.hoteleria.roomsOps.controller;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hoteleria.roomsOps.service.RoleService;
+import com.hoteleria.roomsOps.dto.RoleDto;
+
+@RestController
+@RequestMapping("api/v1/roles")
+public class RoleController {
+
+    @Autowired
+    private RoleService roleService;
+
+    @GetMapping
+    public List<RoleDto> listRoles(){
+        return roleService.getRoles();
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String,Object>> createRole(@RequestBody RoleDto dto){
+        Map<String,Object> resp = new HashMap<>();
+        try{
+            RoleDto created = roleService.createRole(dto);
+            resp.put("message", "Rol generado correctamente");
+            resp.put("role", created);
+            return ResponseEntity.status(HttpStatus.CREATED).body(resp);
+        } catch (Exception e){
+            resp.put("message", "Error al crear rol");
+            resp.put("error", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(resp);
+        }
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Object> getRole(@PathVariable Long id){
+        RoleDto dto = roleService.findById(id);
+        if (dto == null) {
+            return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(Map.of("message","Rol no encontrado"));
+        }
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Object> updateRole(@PathVariable Long id, @RequestBody RoleDto dto){
+        try{
+            RoleDto updated = roleService.updateRole(id, dto);
+            return ResponseEntity.ok(Map.of("message","Rol actualizado","role", updated));
+        } catch (Exception e){
+            return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message","Error al actualizar rol","error", e.getMessage()));
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Object> deleteRole(@PathVariable Long id){
+        try{
+            roleService.deleteRole(id);
+            return ResponseEntity.ok(Map.of("message","Rol eliminado"));
+        } catch (Exception e){
+            if (e.getMessage() != null && e.getMessage().contains("not found")) {
+                return ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("message","Rol no encontrado","error", e.getMessage()));
+            }
+            return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message","Error al eliminar rol","error", e.getMessage()));
+        }
+    }
+}
+

--- a/src/main/java/com/hoteleria/roomsOps/controller/RoleController.java
+++ b/src/main/java/com/hoteleria/roomsOps/controller/RoleController.java
@@ -29,11 +29,11 @@ public class RoleController {
         Map<String,Object> resp = new HashMap<>();
         try{
             RoleDto created = roleService.createRole(dto);
-            resp.put("message", "Rol generado correctamente");
+            resp.put("mensaje", "Rol generado correctamente");
             resp.put("role", created);
             return ResponseEntity.status(HttpStatus.CREATED).body(resp);
         } catch (Exception e){
-            resp.put("message", "Error al crear rol");
+            resp.put("mensaje", "Error al crear rol");
             resp.put("error", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(resp);
         }
@@ -45,7 +45,7 @@ public class RoleController {
         if (dto == null) {
             return ResponseEntity
                 .status(HttpStatus.NOT_FOUND)
-                .body(Map.of("message","Rol no encontrado"));
+                .body(Map.of("mensaje","Rol no encontrado"));
         }
         return ResponseEntity.ok(dto);
     }
@@ -54,11 +54,11 @@ public class RoleController {
     public ResponseEntity<Object> updateRole(@PathVariable Long id, @RequestBody RoleDto dto){
         try{
             RoleDto updated = roleService.updateRole(id, dto);
-            return ResponseEntity.ok(Map.of("message","Rol actualizado","role", updated));
+            return ResponseEntity.ok(Map.of("mensaje","Rol actualizado","role", updated));
         } catch (Exception e){
             return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message","Error al actualizar rol","error", e.getMessage()));
+                .body(Map.of("mensaje","Error al actualizar rol","error", e.getMessage()));
         }
     }
 
@@ -66,16 +66,20 @@ public class RoleController {
     public ResponseEntity<Object> deleteRole(@PathVariable Long id){
         try{
             roleService.deleteRole(id);
-            return ResponseEntity.ok(Map.of("message","Rol eliminado"));
+            return ResponseEntity.ok(Map.of("mensaje","Rol eliminado"));
         } catch (Exception e){
-            if (e.getMessage() != null && e.getMessage().contains("not found")) {
+
+            // en caso de que sea Null, le asigno un mensaje genérico para evitar NullPointerException al acceder a getMessage()
+            String errorMsg = e.getMessage() != null ? e.getMessage() : "Error desconocido";
+
+            if (errorMsg.toLowerCase().contains("no encontrado")) {
                 return ResponseEntity
                     .status(HttpStatus.NOT_FOUND)
-                    .body(Map.of("message","Rol no encontrado","error", e.getMessage()));
+                    .body(Map.of("mensaje","Rol no encontrado","error", errorMsg));
             }
             return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message","Error al eliminar rol","error", e.getMessage()));
+                .body(Map.of("mensaje","Error al eliminar rol","error", errorMsg));
         }
     }
 }

--- a/src/main/java/com/hoteleria/roomsOps/dto/RoleDto.java
+++ b/src/main/java/com/hoteleria/roomsOps/dto/RoleDto.java
@@ -1,0 +1,32 @@
+package com.hoteleria.roomsOps.dto;
+
+import com.hoteleria.roomsOps.model.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleDto {
+    private Long id;
+    private String name;
+
+    public static RoleDto fromEntity(Role r){
+    if (r == null) return null;
+    return RoleDto.builder()
+            .id(r.getId())
+            .name(r.getName())
+            .build();
+    }
+
+    public static Role toEntity(RoleDto dto){
+        if (dto == null) return null;
+        return Role.builder()
+                .id(dto.getId())
+                .name(dto.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/hoteleria/roomsOps/model/Role.java
+++ b/src/main/java/com/hoteleria/roomsOps/model/Role.java
@@ -1,0 +1,30 @@
+package com.hoteleria.roomsOps.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "roles")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Role {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public Role(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/hoteleria/roomsOps/model/User.java
+++ b/src/main/java/com/hoteleria/roomsOps/model/User.java
@@ -1,0 +1,39 @@
+package com.hoteleria.roomsOps.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 10)
+    private String run;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "role_id", nullable = false)
+    private Role role;
+
+}

--- a/src/main/java/com/hoteleria/roomsOps/repository/RoleRepo.java
+++ b/src/main/java/com/hoteleria/roomsOps/repository/RoleRepo.java
@@ -1,0 +1,15 @@
+package com.hoteleria.roomsOps.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.hoteleria.roomsOps.model.Role;
+
+@Repository
+public interface RoleRepo extends JpaRepository<Role, Long> {
+
+	Optional<Role> findByName(String name);
+
+}

--- a/src/main/java/com/hoteleria/roomsOps/service/RoleService.java
+++ b/src/main/java/com/hoteleria/roomsOps/service/RoleService.java
@@ -1,0 +1,46 @@
+package com.hoteleria.roomsOps.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.hoteleria.roomsOps.model.Role;
+import com.hoteleria.roomsOps.repository.RoleRepo;
+import com.hoteleria.roomsOps.dto.RoleDto;
+
+@Service
+public class RoleService {
+    
+    @Autowired
+    private RoleRepo repo;
+
+    public List<RoleDto> getRoles(){
+        return repo.findAll().stream().map(RoleDto::fromEntity).collect(Collectors.toList());
+    }
+
+    public RoleDto createRole(RoleDto dto){
+        Role r = RoleDto.toEntity(dto);
+        Role saved = repo.save(r);
+        return RoleDto.fromEntity(saved);
+    }
+
+    public RoleDto findById(Long id){
+        return repo.findById(id).map(RoleDto::fromEntity).orElse(null);
+    }
+
+    public RoleDto updateRole(Long id, RoleDto dto){
+        Role existing = repo.findById(id).orElseThrow(() -> new IllegalArgumentException("Role not found"));
+        existing.setName(dto.getName());
+        Role saved = repo.save(existing);
+        return RoleDto.fromEntity(saved);
+    }
+
+    public void deleteRole(Long id){
+        if (!repo.existsById(id)) {
+            throw new IllegalArgumentException("Role not found");
+        }
+        repo.deleteById(id);
+    }
+}

--- a/src/main/java/com/hoteleria/roomsOps/service/RoleService.java
+++ b/src/main/java/com/hoteleria/roomsOps/service/RoleService.java
@@ -31,7 +31,7 @@ public class RoleService {
     }
 
     public RoleDto updateRole(Long id, RoleDto dto){
-        Role existing = repo.findById(id).orElseThrow(() -> new IllegalArgumentException("Role not found"));
+        Role existing = repo.findById(id).orElseThrow(() -> new IllegalArgumentException("Rol no encontrado"));
         existing.setName(dto.getName());
         Role saved = repo.save(existing);
         return RoleDto.fromEntity(saved);
@@ -39,7 +39,7 @@ public class RoleService {
 
     public void deleteRole(Long id){
         if (!repo.existsById(id)) {
-            throw new IllegalArgumentException("Role not found");
+            throw new IllegalArgumentException("Rol no encontrado");
         }
         repo.deleteById(id);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,3 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 server.port=8080
-
-
-jwt.secret=H2qZ7uR6o4m8jPMg8Wkq9aN3Zqv0rBfGJmW6sS7Kc2E=

--- a/src/test/java/com/hoteleria/roomsOps/controller/RoleControllerTest.java
+++ b/src/test/java/com/hoteleria/roomsOps/controller/RoleControllerTest.java
@@ -1,0 +1,207 @@
+package com.hoteleria.roomsOps.controller;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hoteleria.roomsOps.dto.RoleDto;
+import com.hoteleria.roomsOps.service.RoleService;
+
+// Carga solo la capa web para probar el controlador en aislamiento.
+@WebMvcTest(RoleController.class)
+class RoleControllerTest {
+
+    // Cliente de pruebas HTTP para invocar endpoints sin levantar servidor real.
+    @Autowired
+    private MockMvc mockMvc;
+
+    // Convierte objetos Java a JSON para enviar cuerpos en POST/PUT.
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    // Mock de la dependencia del controlador para controlar respuestas del servicio.
+    @MockBean
+    private RoleService roleService;
+
+    @Test
+    void listRoles() throws Exception {
+        // Simula que el servicio devuelve dos roles.
+        when(roleService.getRoles()).thenReturn(List.of(
+                RoleDto.builder().id(1L).name("ADMIN").build(),
+                RoleDto.builder().id(2L).name("TRABAJADOR").build()));
+
+        // Ejecuta GET /api/v1/roles contra el controlador.
+        mockMvc.perform(get("/api/v1/roles"))
+                // Verifica estado HTTP 200.
+                .andExpect(status().isOk())
+                // Verifica contenido del arreglo JSON de respuesta.
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("ADMIN"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].name").value("TRABAJADOR"));
+    }
+
+    @Test
+    void createRoleCreated() throws Exception {
+        // DTO que enviamos como body del POST.
+        RoleDto request = RoleDto.builder().name("SUPERVISOR").build();
+        // DTO que simula devolver el servicio al crear exitosamente.
+        RoleDto created = RoleDto.builder().id(10L).name("SUPERVISOR").build();
+
+        // Configura el comportamiento del mock para cualquier RoleDto recibido.
+        when(roleService.createRole(org.mockito.ArgumentMatchers.any(RoleDto.class))).thenReturn(created);
+
+        // Ejecuta POST enviando JSON y verifica respuesta de creación.
+        mockMvc.perform(post("/api/v1/roles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        // Serializa el DTO a JSON.
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.mensaje").value("Rol generado correctamente"))
+                .andExpect(jsonPath("$.role.id").value(10))
+                .andExpect(jsonPath("$.role.name").value("SUPERVISOR"));
+    }
+
+    @Test
+    void createRoleBadRequest() throws Exception {
+        // DTO con nombre que provocará error simulado.
+        RoleDto request = RoleDto.builder().name("ADMIN").build();
+        // Simula excepción de negocio del servicio.
+        when(roleService.createRole(org.mockito.ArgumentMatchers.any(RoleDto.class)))
+                .thenThrow(new IllegalArgumentException("Nombre duplicado"));
+
+        // Ejecuta POST y valida respuesta HTTP 400 con mensaje de error.
+        mockMvc.perform(post("/api/v1/roles")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensaje").value("Error al crear rol"))
+                .andExpect(jsonPath("$.error").value("Nombre duplicado"));
+    }
+
+    @Test
+    void getRoleOk() throws Exception {
+        // Simula que existe un rol para el id consultado.
+        RoleDto role = RoleDto.builder().id(5L).name("ADMIN").build();
+        when(roleService.findById(5L)).thenReturn(role);
+
+        // Ejecuta GET por id y verifica respuesta 200 con body esperado.
+        mockMvc.perform(get("/api/v1/roles/5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.name").value("ADMIN"));
+    }
+
+    @Test
+    void getRoleNotFound() throws Exception {
+        // Simula ausencia del rol en el servicio.
+        when(roleService.findById(99L)).thenReturn(null);
+
+        // Ejecuta GET por id inexistente y verifica 404.
+        mockMvc.perform(get("/api/v1/roles/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.mensaje").value("Rol no encontrado"));
+    }
+
+    @Test
+    void updateRoleOk() throws Exception {
+        // Request de actualización.
+        RoleDto request = RoleDto.builder().name("NEW_NAME").build();
+        // Respuesta simulada del servicio.
+        RoleDto updated = RoleDto.builder().id(7L).name("NEW_NAME").build();
+
+        // Define resultado exitoso del mock en actualización.
+        when(roleService.updateRole(org.mockito.ArgumentMatchers.eq(7L),
+                org.mockito.ArgumentMatchers.any(RoleDto.class))).thenReturn(updated);
+
+        // Ejecuta PUT y valida respuesta 200 con payload de rol actualizado.
+        mockMvc.perform(put("/api/v1/roles/7")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mensaje").value("Rol actualizado"))
+                .andExpect(jsonPath("$.role.id").value(7))
+                .andExpect(jsonPath("$.role.name").value("NEW_NAME"));
+    }
+
+    @Test
+    void updateRoleBadRequest() throws Exception {
+        // Request que provoca error de validación simulado.
+        RoleDto request = RoleDto.builder().name("FAIL").build();
+
+        // Simula excepción de negocio para la actualización.
+        when(roleService.updateRole(org.mockito.ArgumentMatchers.eq(8L),
+                org.mockito.ArgumentMatchers.any(RoleDto.class)))
+                .thenThrow(new IllegalArgumentException("Dato invalido"));
+
+        // Ejecuta PUT y verifica estado 400 con mensaje de error.
+        mockMvc.perform(put("/api/v1/roles/8")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensaje").value("Error al actualizar rol"))
+                .andExpect(jsonPath("$.error").value("Dato invalido"));
+    }
+
+    @Test
+    void deleteRoleOk() throws Exception {
+        // Simula eliminación exitosa (sin excepción).
+        doNothing().when(roleService).deleteRole(9L);
+
+        // Ejecuta DELETE y valida respuesta 200.
+        mockMvc.perform(delete("/api/v1/roles/9"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mensaje").value("Rol eliminado"));
+    }
+
+    @Test
+    void deleteRoleNotFound() throws Exception {
+        // Simula que el rol no existe al eliminar.
+        doThrow(new IllegalArgumentException("Rol no encontrado")).when(roleService).deleteRole(100L);
+
+        // Ejecuta DELETE y verifica estado 404 con mensaje esperado.
+        mockMvc.perform(delete("/api/v1/roles/100"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.mensaje").value("Rol no encontrado"))
+                .andExpect(jsonPath("$.error").value("Rol no encontrado"));
+    }
+
+    @Test
+    void deleteRoleBadRequest() throws Exception {
+        // Simula error genérico de negocio al eliminar.
+        doThrow(new IllegalArgumentException("error de negocio")).when(roleService).deleteRole(101L);
+
+        // Ejecuta DELETE y valida estado 400 con detalle del error.
+        mockMvc.perform(delete("/api/v1/roles/101"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensaje").value("Error al eliminar rol"))
+                .andExpect(jsonPath("$.error").value("error de negocio"));
+    }
+
+    @Test
+    void deleteRoleErrorWithNullMessage() throws Exception {
+        doThrow(new IllegalArgumentException((String) null))
+                .when(roleService).deleteRole(200L);
+
+        mockMvc.perform(delete("/api/v1/roles/200"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensaje").value("Error al eliminar rol"));
+        }
+
+}

--- a/src/test/java/com/hoteleria/roomsOps/service/RoleServiceTest.java
+++ b/src/test/java/com/hoteleria/roomsOps/service/RoleServiceTest.java
@@ -1,0 +1,121 @@
+package com.hoteleria.roomsOps.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hoteleria.roomsOps.dto.RoleDto;
+import com.hoteleria.roomsOps.model.Role;
+import com.hoteleria.roomsOps.repository.RoleRepo;
+
+@ExtendWith(MockitoExtension.class)
+class RoleServiceTest {
+
+    @Mock
+    private RoleRepo repo;
+
+    @InjectMocks
+    private RoleService service;
+
+    @Test
+    void listRoles() {
+        Role role = Role.builder().id(1L).name("ADMIN").build();
+        when(repo.findAll()).thenReturn(List.of(role));
+
+        List<RoleDto> result = service.getRoles();
+
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getId());
+        assertEquals("ADMIN", result.get(0).getName());
+    }
+
+    @Test
+    void createRole() {
+        RoleDto dto = RoleDto.builder().name("SUPERVISOR").build();
+        Role saved = Role.builder().id(10L).name("SUPERVISOR").build();
+        when(repo.save(any(Role.class))).thenReturn(saved);
+
+        RoleDto result = service.createRole(dto);
+
+        assertEquals(10L, result.getId());
+        assertEquals("SUPERVISOR", result.getName());
+    }
+
+    @Test
+    void findByIdFound() {
+        Role role = Role.builder().id(2L).name("USER").build();
+        when(repo.findById(2L)).thenReturn(Optional.of(role));
+
+        RoleDto result = service.findById(2L);
+
+        assertEquals(2L, result.getId());
+        assertEquals("USER", result.getName());
+    }
+
+    @Test
+    void findByIdMissing() {
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        RoleDto result = service.findById(99L);
+
+        assertEquals(null, result);
+    }
+
+    @Test
+    void updateRole() {
+        Role existing = Role.builder().id(3L).name("OLD").build();
+        RoleDto dto = RoleDto.builder().name("NEW").build();
+
+        when(repo.findById(3L)).thenReturn(Optional.of(existing));
+        when(repo.save(any(Role.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RoleDto result = service.updateRole(3L, dto);
+
+        assertEquals(3L, result.getId());
+        assertEquals("NEW", result.getName());
+    }
+
+    @Test
+    void updateRoleMissing() {
+        RoleDto dto = RoleDto.builder().name("NEW").build();
+        when(repo.findById(77L)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.updateRole(77L, dto));
+
+        assertTrue(ex.getMessage().contains("Rol no encontrado"));
+    }
+
+    @Test
+    void deleteRole() {
+        when(repo.existsById(4L)).thenReturn(true);
+
+        service.deleteRole(4L);
+
+        verify(repo).deleteById(4L);
+    }
+
+    @Test
+    void deleteRoleMissing() {
+        when(repo.existsById(55L)).thenReturn(false);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.deleteRole(55L));
+
+        assertTrue(ex.getMessage().contains("Rol no encontrado"));
+        verify(repo, never()).deleteById(any(Long.class));
+    }
+}

--- a/target/classes/application.properties
+++ b/target/classes/application.properties
@@ -14,6 +14,3 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 server.port=8080
-
-
-jwt.secret=H2qZ7uR6o4m8jPMg8Wkq9aN3Zqv0rBfGJmW6sS7Kc2E=

--- a/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
+++ b/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
@@ -1,1 +1,8 @@
 /home/sebastian/portafolio/RoomOps-back/src/main/java/com/hoteleria/roomsOps/Application.java
+/home/sebastian/portafolio/RoomOps-back/src/main/java/com/hoteleria/roomsOps/config/Initializer.java
+/home/sebastian/portafolio/RoomOps-back/src/main/java/com/hoteleria/roomsOps/controller/RoleController.java
+/home/sebastian/portafolio/RoomOps-back/src/main/java/com/hoteleria/roomsOps/dto/RoleDto.java
+/home/sebastian/portafolio/RoomOps-back/src/main/java/com/hoteleria/roomsOps/model/Role.java
+/home/sebastian/portafolio/RoomOps-back/src/main/java/com/hoteleria/roomsOps/model/User.java
+/home/sebastian/portafolio/RoomOps-back/src/main/java/com/hoteleria/roomsOps/repository/RoleRepo.java
+/home/sebastian/portafolio/RoomOps-back/src/main/java/com/hoteleria/roomsOps/service/RoleService.java


### PR DESCRIPTION
# Descripción del Pull Request

Este PR implementa una base inicial para la gestión de usuarios y roles en RoomOps, junto con la integración de pruebas automatizadas y reportes de cobertura en el pipeline de CI.

## Backend: Gestión de Usuarios y Roles

- Se crearon las entidades `User` y `Role` con JPA.  
- Se implementó `RoleDto` para transferencia de datos.  
- Se agregó `RoleRepo` para acceso a datos.  
- Se desarrolló `RoleService` con lógica CRUD.  
- Se expuso `RoleController` con endpoints REST.

## Mejoras en Build y CI/CD

- Se actualizó el `pom.xml` con dependencias necesarias y configuración de JaCoCo.  
- Se agregó un workflow de GitHub Actions para ejecutar tests y generar reportes en PR hacia `master`.  
- Se ajustó el despliegue Docker para ejecución manual.

## Otros Cambios

- Se comentó el inicializador de datos por defecto.  
- Se limpió `application.properties` eliminando configuración no utilizada.

## Issues relacionados

- Closes #3 (Roles)
- Closes #4 (Modelo)
- Closes #5 (Repository)
- Closes #6 (Service)
- Closes #7 (Controller)
- Closes #8 (DTO)
- Closes #9 (Tests)