### PR TITLE
update test unitarios de usuarios

### DIFF
--- a/src/test/java/com/hoteleria/roomsOps/service/UserServiceTest.java
+++ b/src/test/java/com/hoteleria/roomsOps/service/UserServiceTest.java
@@ -167,6 +167,39 @@ class UserServiceTest {
         verify(userRepo, never()).save(any(User.class));
     }
 
+        @Test
+        void createUserWithNullRunSkipsRunDuplicateCheck() {
+                UserDto dto = UserDto.builder()
+                                .run(null)
+                                .firstName("Juan")
+                                .lastName("Olguin")
+                                .email("juan@example.com")
+                                .password("prueba")
+                                .role("trabajador")
+                                .build();
+
+                Role role = Role.builder().id(1L).name("trabajador").build();
+                User saved = User.builder()
+                                .id(1L)
+                                .run(null)
+                                .firstName("Juan")
+                                .lastName("Olguin")
+                                .email("juan@example.com")
+                                .password("prueba")
+                                .role(role)
+                                .build();
+
+                when(userRepo.existsByEmail("juan@example.com")).thenReturn(false);
+                when(roleRepo.findByName("trabajador")).thenReturn(Optional.of(role));
+                when(userRepo.save(any(User.class))).thenReturn(saved);
+
+                UserDto result = service.createUser(dto);
+
+                assertNotNull(result);
+                assertEquals("juan@example.com", result.getEmail());
+                verify(userRepo, never()).existsByRun(any(String.class));
+        }
+
     @Test
     void findByIdFound() {
         Role role = Role.builder().id(1L).name("trabajador").build();
@@ -262,6 +295,71 @@ class UserServiceTest {
     }
 
     @Test
+    void updateUserSkipsPasswordAndRoleWhenNotProvided() {
+        Role oldRole = Role.builder().id(1L).name("trabajador").build();
+
+        User existing = User.builder()
+                .id(1L)
+                .run("12345678-9")
+                .firstName("Juan")
+                .lastName("Olguin")
+                .email("juan@example.com")
+                .password("vieja")
+                .role(oldRole)
+                .build();
+
+        UserDto dto = UserDto.builder()
+                .run("12345678-9")
+                .firstName("Juan")
+                .lastName("Olguin")
+                .email("juan@example.com")
+                .password("")
+                .role(null)
+                .build();
+
+        when(userRepo.findById(1L)).thenReturn(Optional.of(existing));
+        when(userRepo.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserDto result = service.updateUser(1L, dto);
+
+        assertEquals("vieja", result.getPassword());
+        assertEquals("trabajador", result.getRole());
+        verify(roleRepo, never()).findByName(any(String.class));
+    }
+
+    @Test
+    void updateUserFailsWhenRoleNotFound() {
+        Role oldRole = Role.builder().id(1L).name("trabajador").build();
+
+        User existing = User.builder()
+                .id(1L)
+                .run("12345678-9")
+                .firstName("Juan")
+                .lastName("Olguin")
+                .email("juan@example.com")
+                .password("vieja")
+                .role(oldRole)
+                .build();
+
+        UserDto dto = UserDto.builder()
+                .run("12345678-9")
+                .firstName("Juan")
+                .lastName("Olguin")
+                .email("juan@example.com")
+                .role("inexistente")
+                .build();
+
+        when(userRepo.findById(1L)).thenReturn(Optional.of(existing));
+        when(roleRepo.findByName("inexistente")).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> service.updateUser(1L, dto));
+
+        assertTrue(ex.getMessage().contains("Role not found"));
+        verify(userRepo, never()).save(any(User.class));
+    }
+
+    @Test
     void deleteUserSuccess() {
         when(userRepo.existsById(10L)).thenReturn(true);
 
@@ -334,6 +432,54 @@ class UserServiceTest {
 
         assertEquals("vieja", result.getPassword());
     }
+
+        @Test
+        void patchUserWithoutPasswordFieldKeepsCurrentPassword() {
+                Role role = Role.builder().id(1L).name("trabajador").build();
+                User existing = User.builder()
+                                .id(1L)
+                                .run("12345678-9")
+                                .firstName("Juan")
+                                .lastName("Olguin")
+                                .email("juan@example.com")
+                                .password("vieja")
+                                .role(role)
+                                .build();
+
+                Map<String, Object> updates = Map.of("firstName", "Pedro");
+
+                when(userRepo.findById(1L)).thenReturn(Optional.of(existing));
+                when(userRepo.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+                UserDto result = service.patchUser(1L, updates);
+
+                assertEquals("Pedro", result.getFirstName());
+                assertEquals("vieja", result.getPassword());
+        }
+
+        @Test
+        void patchUserDoesNotOverrideWithNullPassword() {
+                Role role = Role.builder().id(1L).name("trabajador").build();
+                User existing = User.builder()
+                                .id(1L)
+                                .run("12345678-9")
+                                .firstName("Juan")
+                                .lastName("Olguin")
+                                .email("juan@example.com")
+                                .password("vieja")
+                                .role(role)
+                                .build();
+
+                Map<String, Object> updates = new HashMap<>();
+                updates.put("password", null);
+
+                when(userRepo.findById(1L)).thenReturn(Optional.of(existing));
+                when(userRepo.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+                UserDto result = service.patchUser(1L, updates);
+
+                assertEquals("vieja", result.getPassword());
+        }
 
     @Test
     void patchUserFailsWhenMissing() {


### PR DESCRIPTION
Este *pull request* agrega varias pruebas unitarias nuevas a la clase `UserServiceTest` para mejorar la cobertura de los escenarios de creación, actualización y modificación parcial (*patching*) de usuarios. Las nuevas pruebas se enfocan en asegurar el manejo correcto de los campos nulos o faltantes, especialmente para los atributos `password`, `role` y `run`, y en verificar que las comprobaciones de duplicados y las actualizaciones se omitan o se apliquen correctamente según corresponda.

**Casos límite en la creación y actualización de usuarios:**

* Se agregó una prueba para verificar que, al crear un usuario con un `run` nulo, se omite la comprobación de `run` duplicado.
* Se agregó una prueba para asegurar que la actualización de un usuario omite los cambios de contraseña y rol cuando esos campos no se proporcionan (están vacíos o son nulos), y no realiza llamadas innecesarias al repositorio de roles.
* Se agregó una prueba para confirmar que la actualización de un usuario falla con una excepción adecuada si el rol proporcionado no existe.

**Comportamientos en la modificación parcial (*patching*) de usuarios:**

* Se agregó una prueba para asegurar que, al aplicar un *patch* a un usuario sin un campo `password`, se conserva la contraseña actual.
* Se agregó una prueba para confirmar que aplicar un *patch* a un usuario con un `password` nulo no sobrescribe la contraseña existente.