### PR TITLE
implementacion de las tareas

### DIFF
--- a/src/main/java/com/hoteleria/roomsOps/controller/TaskController.java
+++ b/src/main/java/com/hoteleria/roomsOps/controller/TaskController.java
@@ -1,0 +1,88 @@
+package com.hoteleria.roomsOps.controller;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hoteleria.roomsOps.dto.TaskDto;
+import com.hoteleria.roomsOps.service.TaskService;
+
+@RestController
+@RequestMapping("api/v1/tasks")
+public class TaskController {
+
+	@Autowired
+	private TaskService taskService;
+
+	@GetMapping
+	public List<TaskDto> listTasks() {
+		return taskService.getAllTasks();
+	}
+
+	@PostMapping
+	public ResponseEntity<Map<String, Object>> createTask(@RequestBody TaskDto dto) {
+		Map<String, Object> response = new HashMap<>();
+		try {
+			TaskDto created = taskService.createTask(dto);
+			response.put("mensaje", "Tarea generada correctamente");
+			response.put("tarea", created);
+			return ResponseEntity.status(HttpStatus.CREATED).body(response);
+		} catch (Exception e) {
+			response.put("mensaje", "Error al crear tarea");
+			response.put("error", e.getMessage());
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+		}
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<Object> getTask(@PathVariable Long id) {
+		TaskDto dto = taskService.getTaskById(id);
+		if (dto == null) {
+			return ResponseEntity
+					.status(HttpStatus.NOT_FOUND)
+					.body(Map.of("mensaje", "Tarea no encontrada"));
+		}
+		return ResponseEntity.ok(dto);
+	}
+
+	@PutMapping("/{id}")
+	public ResponseEntity<Object> updateTask(@PathVariable Long id, @RequestBody TaskDto dto) {
+		try {
+			TaskDto updated = taskService.updateTask(id, dto);
+			if (updated == null) {
+				return ResponseEntity
+						.status(HttpStatus.NOT_FOUND)
+						.body(Map.of("mensaje", "Tarea no encontrada"));
+			}
+			return ResponseEntity.ok(Map.of("mensaje", "Tarea actualizada", "tarea", updated));
+		} catch (Exception e) {
+			return ResponseEntity
+					.status(HttpStatus.BAD_REQUEST)
+					.body(Map.of("mensaje", "Error al actualizar tarea", "error", e.getMessage()));
+		}
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Object> deleteTask(@PathVariable Long id) {
+		try {
+			taskService.deleteTask(id);
+			return ResponseEntity.ok(Map.of("mensaje", "Tarea eliminada"));
+		} catch (Exception e) {
+			return ResponseEntity
+					.status(HttpStatus.BAD_REQUEST)
+					.body(Map.of("mensaje", "Error al eliminar tarea", "error", e.getMessage()));
+		}
+	}
+}

--- a/src/main/java/com/hoteleria/roomsOps/dto/TaskDto.java
+++ b/src/main/java/com/hoteleria/roomsOps/dto/TaskDto.java
@@ -1,0 +1,83 @@
+package com.hoteleria.roomsOps.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import com.hoteleria.roomsOps.model.ChecklistItem;
+import com.hoteleria.roomsOps.model.Task;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TaskDto {
+    private Long id;
+    private String titulo;
+    private String descripcion;
+
+    @JsonProperty("apartamentoId")
+    @JsonAlias("apartmentId")
+    private Long apartmentId;
+
+    @JsonProperty("usuarioAsignadoId")
+    @JsonAlias("assignedUserId")
+    private Long assignedUserId;
+
+    @JsonProperty("estadoId")
+    @JsonAlias("statusId")
+    private Long statusId;
+
+    @Builder.Default
+    @JsonProperty("listaVerificacion")
+    @JsonAlias("checklist")
+    private List<ChecklistItem> checklist = new ArrayList<>();
+
+    public static TaskDto fromEntity(Task t){
+        if (t == null) return null;
+        return TaskDto.builder()
+                .id(t.getId())
+                .titulo(t.getTitulo())
+                .descripcion(t.getDescripcion())
+            .apartmentId(t.getApartment() != null ? t.getApartment().getId() : null)
+            .assignedUserId(t.getAssignedTo() != null ? t.getAssignedTo().getId() : null)
+            .statusId(t.getStatus() != null ? t.getStatus().getId() : null)
+            .checklist(t.getChecklist() == null ? new ArrayList<>() : t.getChecklist().stream()
+                .map(TaskDto::copyChecklistItem)
+                .collect(Collectors.toList()))
+                .build();
+    }
+
+    public static Task toEntity(TaskDto dto){
+        if (dto == null) return null;
+        return Task.builder()
+                .id(dto.getId())
+                .titulo(dto.getTitulo())
+                .descripcion(dto.getDescripcion())
+                .checklist(dto.getChecklist() == null ? new ArrayList<>() : dto.getChecklist().stream()
+                        .map(TaskDto::copyChecklistItem)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    private static ChecklistItem copyChecklistItem(ChecklistItem item) {
+        if (item == null) {
+            return null;
+        }
+
+        return ChecklistItem.builder()
+                .descripcion(item.getDescripcion())
+                .estado(item.getEstado())
+                .nota(item.getNota())
+                .build();
+    }
+}
+

--- a/src/main/java/com/hoteleria/roomsOps/model/ChecklistItem.java
+++ b/src/main/java/com/hoteleria/roomsOps/model/ChecklistItem.java
@@ -1,0 +1,24 @@
+package com.hoteleria.roomsOps.model;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChecklistItem {
+
+    private String descripcion;
+
+    @Enumerated(EnumType.STRING)
+    private ChecklistStatus estado;
+
+    private String nota;
+}

--- a/src/main/java/com/hoteleria/roomsOps/model/ChecklistStatus.java
+++ b/src/main/java/com/hoteleria/roomsOps/model/ChecklistStatus.java
@@ -1,0 +1,8 @@
+package com.hoteleria.roomsOps.model;
+
+public enum ChecklistStatus {
+    PENDIENTE,
+    EN_PROGRESO,
+    HECHO,
+    BLOQUEADO
+}

--- a/src/main/java/com/hoteleria/roomsOps/model/Task.java
+++ b/src/main/java/com/hoteleria/roomsOps/model/Task.java
@@ -1,0 +1,43 @@
+package com.hoteleria.roomsOps.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "tasks")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String titulo;
+
+    private String descripcion;
+
+    @ManyToOne
+    @JoinColumn(name = "apartment_id", nullable = false)
+    private Apartment apartment;
+
+    @ManyToOne
+    @JoinColumn(name = "assigned_to")
+    private User assignedTo;
+
+    @ManyToOne
+    @JoinColumn(name = "status_id", nullable = false)
+    private Status status;
+
+    @Builder.Default
+    @ElementCollection
+    @CollectionTable(name = "task_checklist", joinColumns = @JoinColumn(name = "task_id"))
+    private List<ChecklistItem> checklist = new ArrayList<>();
+}
+

--- a/src/main/java/com/hoteleria/roomsOps/repository/TaskRepo.java
+++ b/src/main/java/com/hoteleria/roomsOps/repository/TaskRepo.java
@@ -1,0 +1,12 @@
+package com.hoteleria.roomsOps.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.hoteleria.roomsOps.model.Task;
+
+@Repository
+public interface TaskRepo extends JpaRepository<Task, Long> {
+    Optional<Task> findByTitulo(String titulo);
+}

--- a/src/main/java/com/hoteleria/roomsOps/service/TaskService.java
+++ b/src/main/java/com/hoteleria/roomsOps/service/TaskService.java
@@ -1,0 +1,136 @@
+package com.hoteleria.roomsOps.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.hoteleria.roomsOps.dto.TaskDto;
+import com.hoteleria.roomsOps.model.Apartment;
+import com.hoteleria.roomsOps.model.ChecklistItem;
+import com.hoteleria.roomsOps.model.ChecklistStatus;
+import com.hoteleria.roomsOps.model.Status;
+import com.hoteleria.roomsOps.model.Task;
+import com.hoteleria.roomsOps.model.User;
+import com.hoteleria.roomsOps.repository.ApartmentRepo;
+import com.hoteleria.roomsOps.repository.StatusRepo;
+import com.hoteleria.roomsOps.repository.TaskRepo;
+import com.hoteleria.roomsOps.repository.UserRepo;
+
+@Service
+public class TaskService {
+    @Autowired
+    private TaskRepo taskRepo;
+
+    @Autowired
+    private ApartmentRepo apartmentRepo;
+
+    @Autowired
+    private UserRepo userRepo;
+
+    @Autowired
+    private StatusRepo statusRepo;
+
+    public List<TaskDto> getAllTasks() {
+        return taskRepo.findAll().stream()
+                .map(TaskDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public TaskDto getTaskById(Long id) {
+        return taskRepo.findById(id)
+                .map(TaskDto::fromEntity)
+                .orElse(null);
+    }
+
+    public TaskDto createTask(TaskDto taskDto) {
+        Task task = TaskDto.toEntity(taskDto);
+        applyRelations(task, taskDto, true);
+        task.setChecklist(copyChecklist(taskDto.getChecklist()));
+        task = taskRepo.save(task);
+        return TaskDto.fromEntity(task);
+    }
+
+    public TaskDto updateTask(Long id, TaskDto taskDto) {
+        return taskRepo.findById(id)
+                .map(existingTask -> {
+                    existingTask.setTitulo(taskDto.getTitulo());
+                    existingTask.setDescripcion(taskDto.getDescripcion());
+                    applyRelations(existingTask, taskDto, false);
+                    existingTask.setChecklist(copyChecklist(taskDto.getChecklist()));
+                    existingTask = taskRepo.save(existingTask);
+                    return TaskDto.fromEntity(existingTask);
+                })
+                .orElse(null);
+    }
+
+    public void deleteTask(Long id) {
+        taskRepo.deleteById(id);
+    }
+
+    private void applyRelations(Task task, TaskDto taskDto, boolean creating) {
+        if (creating || taskDto.getApartmentId() != null) {
+            task.setApartment(resolveApartment(taskDto.getApartmentId()));
+        }
+
+        if (creating || taskDto.getStatusId() != null) {
+            task.setStatus(resolveStatus(taskDto.getStatusId()));
+        }
+
+        if (taskDto.getAssignedUserId() != null) {
+            task.setAssignedTo(resolveUser(taskDto.getAssignedUserId()));
+        }
+    }
+
+    private Apartment resolveApartment(Long apartmentId) {
+        if (apartmentId == null) {
+            throw new IllegalArgumentException("El id del apartamento es obligatorio");
+        }
+
+        return apartmentRepo.findById(apartmentId)
+                .orElseThrow(() -> new IllegalArgumentException("Apartamento no encontrado: " + apartmentId));
+    }
+
+    private Status resolveStatus(Long statusId) {
+        if (statusId == null) {
+            throw new IllegalArgumentException("El id del estado es obligatorio");
+        }
+
+        return statusRepo.findById(statusId)
+                .orElseThrow(() -> new IllegalArgumentException("Estado no encontrado: " + statusId));
+    }
+
+    private User resolveUser(Long assignedUserId) {
+        return userRepo.findById(assignedUserId)
+                .orElseThrow(() -> new IllegalArgumentException("Usuario asignado no encontrado: " + assignedUserId));
+    }
+
+    private List<ChecklistItem> copyChecklist(List<ChecklistItem> checklist) {
+        if (checklist == null) {
+            return new ArrayList<>();
+        }
+
+        return checklist.stream()
+                .map(this::validateAndCopyChecklistItem)
+                .collect(Collectors.toList());
+    }
+
+    private ChecklistItem validateAndCopyChecklistItem(ChecklistItem item) {
+        if (item == null) {
+            return null;
+        }
+
+        if (item.getEstado() == ChecklistStatus.BLOQUEADO && (item.getNota() == null || item.getNota().isBlank())) {
+            throw new IllegalArgumentException("La nota es requerida cuando el checklist esta BLOQUEADO");
+        }
+
+        return ChecklistItem.builder()
+                .descripcion(item.getDescripcion())
+                .estado(item.getEstado())
+                .nota(item.getNota())
+                .build();
+    }
+}
+

--- a/src/test/java/com/hoteleria/roomsOps/controller/TaskControllerTest.java
+++ b/src/test/java/com/hoteleria/roomsOps/controller/TaskControllerTest.java
@@ -1,0 +1,173 @@
+package com.hoteleria.roomsOps.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hoteleria.roomsOps.dto.TaskDto;
+import com.hoteleria.roomsOps.service.TaskService;
+
+@WebMvcTest(TaskController.class)
+class TaskControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @MockBean
+    private TaskService service;
+
+    @Test
+    void listTasksOk() throws Exception {
+        when(service.getAllTasks()).thenReturn(List.of(
+                TaskDto.builder().id(1L).titulo("T1").descripcion("D1").build(),
+                TaskDto.builder().id(2L).titulo("T2").descripcion("D2").build()));
+
+        mockMvc.perform(get("/api/v1/tasks"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].titulo").value("T1"))
+                .andExpect(jsonPath("$[1].titulo").value("T2"));
+    }
+
+    @Test
+    void createTaskCreated() throws Exception {
+        TaskDto request = TaskDto.builder()
+                .titulo("Tarea nueva")
+                .descripcion("Detalle")
+                .apartmentId(1L)
+                .statusId(2L)
+                .build();
+
+        TaskDto created = TaskDto.builder()
+                .id(10L)
+                .titulo("Tarea nueva")
+                .descripcion("Detalle")
+                .apartmentId(1L)
+                .statusId(2L)
+                .build();
+
+        when(service.createTask(any(TaskDto.class))).thenReturn(created);
+
+        mockMvc.perform(post("/api/v1/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.mensaje").value("Tarea generada correctamente"))
+                .andExpect(jsonPath("$.tarea.id").value(10))
+                .andExpect(jsonPath("$.tarea.titulo").value("Tarea nueva"));
+    }
+
+    @Test
+    void createTaskBadRequest() throws Exception {
+        TaskDto request = TaskDto.builder().titulo("X").build();
+
+        when(service.createTask(any(TaskDto.class))).thenThrow(new IllegalArgumentException("Datos invalidos"));
+
+        mockMvc.perform(post("/api/v1/tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensaje").value("Error al crear tarea"))
+                .andExpect(jsonPath("$.error").value("Datos invalidos"));
+    }
+
+    @Test
+    void getTaskOk() throws Exception {
+        when(service.getTaskById(5L)).thenReturn(TaskDto.builder().id(5L).titulo("T5").build());
+
+        mockMvc.perform(get("/api/v1/tasks/5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.titulo").value("T5"));
+    }
+
+    @Test
+    void getTaskNotFound() throws Exception {
+        when(service.getTaskById(99L)).thenReturn(null);
+
+        mockMvc.perform(get("/api/v1/tasks/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.mensaje").value("Tarea no encontrada"));
+    }
+
+    @Test
+    void updateTaskOk() throws Exception {
+        TaskDto request = TaskDto.builder().titulo("Nueva").descripcion("Desc").build();
+        TaskDto updated = TaskDto.builder().id(7L).titulo("Nueva").descripcion("Desc").build();
+
+        when(service.updateTask(eq(7L), any(TaskDto.class))).thenReturn(updated);
+
+        mockMvc.perform(put("/api/v1/tasks/7")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mensaje").value("Tarea actualizada"))
+                .andExpect(jsonPath("$.tarea.id").value(7))
+                .andExpect(jsonPath("$.tarea.titulo").value("Nueva"));
+    }
+
+    @Test
+    void updateTaskNotFound() throws Exception {
+        TaskDto request = TaskDto.builder().titulo("Nueva").build();
+        when(service.updateTask(eq(8L), any(TaskDto.class))).thenReturn(null);
+
+        mockMvc.perform(put("/api/v1/tasks/8")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.mensaje").value("Tarea no encontrada"));
+    }
+
+    @Test
+    void updateTaskBadRequest() throws Exception {
+        TaskDto request = TaskDto.builder().titulo("Nueva").build();
+        when(service.updateTask(eq(7L), any(TaskDto.class))).thenThrow(new IllegalArgumentException("Error update"));
+
+        mockMvc.perform(put("/api/v1/tasks/7")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensaje").value("Error al actualizar tarea"))
+                .andExpect(jsonPath("$.error").value("Error update"));
+    }
+
+    @Test
+    void deleteTaskOk() throws Exception {
+        doNothing().when(service).deleteTask(3L);
+
+        mockMvc.perform(delete("/api/v1/tasks/3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mensaje").value("Tarea eliminada"));
+    }
+
+    @Test
+    void deleteTaskBadRequest() throws Exception {
+        doThrow(new IllegalArgumentException("No se puede")).when(service).deleteTask(3L);
+
+        mockMvc.perform(delete("/api/v1/tasks/3"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.mensaje").value("Error al eliminar tarea"))
+                .andExpect(jsonPath("$.error").value("No se puede"));
+    }
+}

--- a/src/test/java/com/hoteleria/roomsOps/service/TaskServiceTest.java
+++ b/src/test/java/com/hoteleria/roomsOps/service/TaskServiceTest.java
@@ -1,0 +1,409 @@
+package com.hoteleria.roomsOps.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hoteleria.roomsOps.dto.TaskDto;
+import com.hoteleria.roomsOps.model.Apartment;
+import com.hoteleria.roomsOps.model.ChecklistItem;
+import com.hoteleria.roomsOps.model.ChecklistStatus;
+import com.hoteleria.roomsOps.model.Status;
+import com.hoteleria.roomsOps.model.Task;
+import com.hoteleria.roomsOps.model.User;
+import com.hoteleria.roomsOps.repository.ApartmentRepo;
+import com.hoteleria.roomsOps.repository.StatusRepo;
+import com.hoteleria.roomsOps.repository.TaskRepo;
+import com.hoteleria.roomsOps.repository.UserRepo;
+
+@ExtendWith(MockitoExtension.class)
+class TaskServiceTest {
+
+    @Mock
+    private TaskRepo taskRepo;
+
+    @Mock
+    private ApartmentRepo apartmentRepo;
+
+    @Mock
+    private UserRepo userRepo;
+
+    @Mock
+    private StatusRepo statusRepo;
+
+    @InjectMocks
+    private TaskService service;
+
+    @Test
+    void getAllTasksOk() {
+        Apartment apartment = Apartment.builder().id(1L).nombre("A-101").activo(true).build();
+        Status status = Status.builder().id(2L).nombre("Pendiente").build();
+        User user = User.builder().id(3L).firstName("Juan").build();
+
+        Task task = Task.builder()
+                .id(10L)
+                .titulo("Limpiar")
+                .descripcion("Limpiar cocina")
+                .apartment(apartment)
+                .status(status)
+                .assignedTo(user)
+                .checklist(List.of(ChecklistItem.builder().descripcion("Trapear").estado(ChecklistStatus.PENDIENTE).build()))
+                .build();
+
+        when(taskRepo.findAll()).thenReturn(List.of(task));
+
+        List<TaskDto> result = service.getAllTasks();
+
+        assertEquals(1, result.size());
+        assertEquals(10L, result.get(0).getId());
+        assertEquals("Limpiar", result.get(0).getTitulo());
+        assertEquals(1L, result.get(0).getApartmentId());
+        assertEquals(2L, result.get(0).getStatusId());
+        assertEquals(3L, result.get(0).getAssignedUserId());
+        assertEquals(1, result.get(0).getChecklist().size());
+    }
+
+    @Test
+    void getTaskByIdFound() {
+        Apartment apartment = Apartment.builder().id(1L).build();
+        Status status = Status.builder().id(2L).build();
+
+        Task task = Task.builder()
+                .id(11L)
+                .titulo("Revisar")
+                .descripcion("Revisar bano")
+                .apartment(apartment)
+                .status(status)
+                .build();
+
+        when(taskRepo.findById(11L)).thenReturn(Optional.of(task));
+
+        TaskDto result = service.getTaskById(11L);
+
+        assertEquals(11L, result.getId());
+        assertEquals("Revisar", result.getTitulo());
+        assertEquals(1L, result.getApartmentId());
+        assertEquals(2L, result.getStatusId());
+    }
+
+    @Test
+    void getTaskByIdMissing() {
+        when(taskRepo.findById(99L)).thenReturn(Optional.empty());
+
+        TaskDto result = service.getTaskById(99L);
+
+        assertNull(result);
+    }
+
+    @Test
+    void createTaskOk() {
+        Apartment apartment = Apartment.builder().id(1L).build();
+        Status status = Status.builder().id(2L).build();
+        User user = User.builder().id(3L).build();
+
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .descripcion("Descripcion")
+                .apartmentId(1L)
+                .statusId(2L)
+                .assignedUserId(3L)
+                .checklist(List.of(ChecklistItem.builder().descripcion("Paso 1").estado(ChecklistStatus.HECHO).build()))
+                .build();
+
+        when(apartmentRepo.findById(1L)).thenReturn(Optional.of(apartment));
+        when(statusRepo.findById(2L)).thenReturn(Optional.of(status));
+        when(userRepo.findById(3L)).thenReturn(Optional.of(user));
+        when(taskRepo.save(any(Task.class))).thenAnswer(invocation -> {
+            Task saved = invocation.getArgument(0);
+            saved.setId(15L);
+            return saved;
+        });
+
+        TaskDto result = service.createTask(dto);
+
+        assertEquals(15L, result.getId());
+        assertEquals("Nueva tarea", result.getTitulo());
+        assertEquals(1L, result.getApartmentId());
+        assertEquals(2L, result.getStatusId());
+        assertEquals(3L, result.getAssignedUserId());
+        assertEquals(1, result.getChecklist().size());
+    }
+
+    @Test
+    void createTaskChecklistBlockedWithoutNote() {
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .apartmentId(1L)
+                .statusId(2L)
+                .checklist(List.of(ChecklistItem.builder()
+                        .descripcion("Paso bloqueado")
+                        .estado(ChecklistStatus.BLOQUEADO)
+                        .nota("   ")
+                        .build()))
+                .build();
+
+        when(apartmentRepo.findById(1L)).thenReturn(Optional.of(Apartment.builder().id(1L).build()));
+        when(statusRepo.findById(2L)).thenReturn(Optional.of(Status.builder().id(2L).build()));
+
+        assertThrows(IllegalArgumentException.class, () -> service.createTask(dto));
+        verify(taskRepo, never()).save(any(Task.class));
+    }
+
+    @Test
+    void createTaskChecklistBlockedWithNullNote() {
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .apartmentId(1L)
+                .statusId(2L)
+                .checklist(List.of(ChecklistItem.builder()
+                        .descripcion("Paso bloqueado")
+                        .estado(ChecklistStatus.BLOQUEADO)
+                        .nota(null)
+                        .build()))
+                .build();
+
+        when(apartmentRepo.findById(1L)).thenReturn(Optional.of(Apartment.builder().id(1L).build()));
+        when(statusRepo.findById(2L)).thenReturn(Optional.of(Status.builder().id(2L).build()));
+
+        assertThrows(IllegalArgumentException.class, () -> service.createTask(dto));
+        verify(taskRepo, never()).save(any(Task.class));
+    }
+
+    @Test
+    void createTaskRequiresApartmentId() {
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .statusId(2L)
+                .build();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> service.createTask(dto));
+
+        assertTrue(ex.getMessage().contains("apartamento"));
+        verify(taskRepo, never()).save(any(Task.class));
+    }
+
+    @Test
+    void createTaskRequiresStatusId() {
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .apartmentId(1L)
+                .build();
+
+        when(apartmentRepo.findById(1L)).thenReturn(Optional.of(Apartment.builder().id(1L).build()));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> service.createTask(dto));
+
+        assertTrue(ex.getMessage().contains("estado"));
+        verify(taskRepo, never()).save(any(Task.class));
+    }
+
+    @Test
+    void createTaskApartmentNotFound() {
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .apartmentId(999L)
+                .statusId(2L)
+                .build();
+
+        when(apartmentRepo.findById(999L)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> service.createTask(dto));
+
+        assertTrue(ex.getMessage().contains("Apartamento no encontrado"));
+        verify(taskRepo, never()).save(any(Task.class));
+    }
+
+    @Test
+    void createTaskStatusNotFound() {
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .apartmentId(1L)
+                .statusId(999L)
+                .build();
+
+        when(apartmentRepo.findById(1L)).thenReturn(Optional.of(Apartment.builder().id(1L).build()));
+        when(statusRepo.findById(999L)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> service.createTask(dto));
+
+        assertTrue(ex.getMessage().contains("Estado no encontrado"));
+        verify(taskRepo, never()).save(any(Task.class));
+    }
+
+    @Test
+    void createTaskAssignedUserNotFound() {
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .apartmentId(1L)
+                .statusId(2L)
+                .assignedUserId(999L)
+                .build();
+
+        when(apartmentRepo.findById(1L)).thenReturn(Optional.of(Apartment.builder().id(1L).build()));
+        when(statusRepo.findById(2L)).thenReturn(Optional.of(Status.builder().id(2L).build()));
+        when(userRepo.findById(999L)).thenReturn(Optional.empty());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> service.createTask(dto));
+
+        assertTrue(ex.getMessage().contains("Usuario asignado no encontrado"));
+        verify(taskRepo, never()).save(any(Task.class));
+    }
+
+    @Test
+    void createTaskHandlesNullChecklist() {
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .apartmentId(1L)
+                .statusId(2L)
+                .checklist(null)
+                .build();
+
+        when(apartmentRepo.findById(1L)).thenReturn(Optional.of(Apartment.builder().id(1L).build()));
+        when(statusRepo.findById(2L)).thenReturn(Optional.of(Status.builder().id(2L).build()));
+        when(taskRepo.save(any(Task.class))).thenAnswer(invocation -> {
+            Task saved = invocation.getArgument(0);
+            saved.setId(16L);
+            return saved;
+        });
+
+        TaskDto result = service.createTask(dto);
+
+        assertEquals(16L, result.getId());
+        assertEquals(0, result.getChecklist().size());
+    }
+
+    @Test
+    void createTaskAllowsNullChecklistItemAndBlockedWithNote() {
+        List<ChecklistItem> checklist = new ArrayList<>();
+        checklist.add(null);
+        checklist.add(ChecklistItem.builder()
+            .descripcion("Paso bloqueado")
+            .estado(ChecklistStatus.BLOQUEADO)
+            .nota("Falta insumo")
+            .build());
+
+        TaskDto dto = TaskDto.builder()
+                .titulo("Nueva tarea")
+                .apartmentId(1L)
+                .statusId(2L)
+            .checklist(checklist)
+                .build();
+
+        when(apartmentRepo.findById(1L)).thenReturn(Optional.of(Apartment.builder().id(1L).build()));
+        when(statusRepo.findById(2L)).thenReturn(Optional.of(Status.builder().id(2L).build()));
+        when(taskRepo.save(any(Task.class))).thenAnswer(invocation -> {
+            Task saved = invocation.getArgument(0);
+            saved.setId(17L);
+            return saved;
+        });
+
+        TaskDto result = service.createTask(dto);
+
+        assertEquals(17L, result.getId());
+        assertEquals(2, result.getChecklist().size());
+        assertNull(result.getChecklist().get(0));
+        assertEquals(ChecklistStatus.BLOQUEADO, result.getChecklist().get(1).getEstado());
+        assertEquals("Falta insumo", result.getChecklist().get(1).getNota());
+    }
+
+    @Test
+    void updateTaskFound() {
+        Apartment apartment = Apartment.builder().id(1L).build();
+        Apartment newApartment = Apartment.builder().id(5L).build();
+        Status status = Status.builder().id(2L).build();
+        Status newStatus = Status.builder().id(6L).build();
+        User existingUser = User.builder().id(3L).build();
+
+        Task existing = Task.builder()
+                .id(20L)
+                .titulo("Antigua")
+                .descripcion("Vieja")
+                .apartment(apartment)
+                .status(status)
+                .assignedTo(existingUser)
+                .build();
+
+        TaskDto request = TaskDto.builder()
+                .titulo("Actualizada")
+                .descripcion("Nueva")
+                .apartmentId(5L)
+                .statusId(6L)
+                .checklist(List.of(ChecklistItem.builder().descripcion("Paso").estado(ChecklistStatus.EN_PROGRESO).build()))
+                .build();
+
+        when(taskRepo.findById(20L)).thenReturn(Optional.of(existing));
+        when(apartmentRepo.findById(5L)).thenReturn(Optional.of(newApartment));
+        when(statusRepo.findById(6L)).thenReturn(Optional.of(newStatus));
+        when(taskRepo.save(any(Task.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        TaskDto result = service.updateTask(20L, request);
+
+        assertEquals(20L, result.getId());
+        assertEquals("Actualizada", result.getTitulo());
+        assertEquals(5L, result.getApartmentId());
+        assertEquals(6L, result.getStatusId());
+        assertEquals(3L, result.getAssignedUserId());
+        assertEquals(1, result.getChecklist().size());
+    }
+
+    @Test
+    void updateTaskMissingReturnsNull() {
+        when(taskRepo.findById(404L)).thenReturn(Optional.empty());
+
+        TaskDto result = service.updateTask(404L, TaskDto.builder().titulo("X").build());
+
+        assertNull(result);
+    }
+
+    @Test
+    void updateTaskKeepsRelationsWhenIdsAreNull() {
+        Apartment apartment = Apartment.builder().id(1L).build();
+        Status status = Status.builder().id(2L).build();
+        User existingUser = User.builder().id(3L).build();
+
+        Task existing = Task.builder()
+                .id(21L)
+                .titulo("Antigua")
+                .descripcion("Vieja")
+                .apartment(apartment)
+                .status(status)
+                .assignedTo(existingUser)
+                .build();
+
+        TaskDto request = TaskDto.builder()
+                .titulo("Actualizada")
+                .descripcion("Nueva")
+                .checklist(List.of(ChecklistItem.builder().descripcion("Paso").estado(ChecklistStatus.HECHO).build()))
+                .build();
+
+        when(taskRepo.findById(21L)).thenReturn(Optional.of(existing));
+        when(taskRepo.save(any(Task.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        TaskDto result = service.updateTask(21L, request);
+
+        assertEquals(1L, result.getApartmentId());
+        assertEquals(2L, result.getStatusId());
+        assertEquals(3L, result.getAssignedUserId());
+    }
+
+    @Test
+    void deleteTaskOk() {
+        service.deleteTask(9L);
+        verify(taskRepo).deleteById(9L);
+    }
+}


### PR DESCRIPTION
Este pull request introduce una nueva funcionalidad de gestión de tareas en la aplicación, incluyendo operaciones CRUD completas para tareas, soporte para listas de verificación con validación, y pruebas exhaustivas a nivel de controlador. La implementación cubre las capas de controlador, servicio, DTO, modelo, repositorio y pruebas, asegurando un mapeo adecuado, validación y manejo de errores a lo largo de toda la aplicación.

### **Funcionalidad de Gestión de Tareas**

* Se agregó un nuevo controlador REST `TaskController` con endpoints para crear, leer, actualizar y eliminar tareas, incluyendo códigos de estado HTTP adecuados y manejo de errores.
* Se introdujo `TaskService` para manejar la lógica de negocio, incluyendo validaciones (por ejemplo, requerir una nota cuando un ítem de checklist está bloqueado), mapeo entre DTOs y entidades, y resolución de relaciones con apartamentos, usuarios y estados.
* Se implementó `TaskDto` para la transferencia de datos, con métodos de mapeo hacia y desde la entidad `Task`, y soporte para ítems de checklist.
* Se agregaron las clases de modelo `Task`, `ChecklistItem` y `ChecklistStatus` para representar las tareas y sus listas de verificación, incluyendo anotaciones JPA para persistencia. [[1]](diffhunk://#diff-bac7ac18f669d25be7da555a46840bb01795d9f3ca3b385a0dd02f7facf646ddR1-R43) [[2]](diffhunk://#diff-3fe01f875b4a0e8873e32d70ee76c260a659a200c873818d757a500f8461afc9R1-R24) [[3]](diffhunk://#diff-ce569aeff716558ade59e3fd05a41bf31f0d57a23b3355ef8960dc972d7363e2R1-R8)
* Se creó `TaskRepo` como repositorio JPA para el acceso a la base de datos de tareas.

### **Pruebas**

* Se agregó `TaskControllerTest` con pruebas unitarias completas para todos los endpoints del controlador, cubriendo escenarios de éxito y error.

### Cierra issues

Closes #24  
Closes #25  
Closes #26  
Closes #27  
Closes #28  
Closes #29  
Closes #30  

Closes #31  
Closes #32  
Closes #33  
Closes #34  
Closes #35  
Closes #36  
Closes #37  
